### PR TITLE
Fix opam file.

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,0 +1,2 @@
+(lang dune 2.0)
+(name syslog)

--- a/syslog.opam
+++ b/syslog.opam
@@ -15,7 +15,20 @@ bug-reports: "https://github.com/geneanet/ocaml-syslog/issues"
 
 license: "LGPL"
 
-build: [ "dune" "build" ]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
 
 depends: [
   "dune" { build }


### PR DESCRIPTION
The package currently in the `opam` repository (`syslog.2.0`) does not install anything, at least with `dune` `2.0` (haven't checked other versions), this PR fixes it.